### PR TITLE
Remove python3 syntax, make unicode compatible with python2

### DIFF
--- a/scripts/blingfire_example.py
+++ b/scripts/blingfire_example.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 from blingfiretok import *
 
-s = "Hello, World! Hello, Café! How do I renew my virtual smart card?: /Microsoft IT/ 'virtual' smart card certificates for DirectAccess are valid for one year. In order to get to microsoft.com we need to type pi@1.2.1.2."
+s = u"Hello, World! Hello, Café! How do I renew my virtual smart card?: /Microsoft IT/ 'virtual' smart card certificates for DirectAccess are valid for one year. In order to get to microsoft.com we need to type pi@1.2.1.2."
 print("Input: " + s)
 
 print("Tokenizer Version: " + str(get_blingfiretok_version()))
@@ -33,7 +34,7 @@ print("Model Handle: %s" % h)
 
 ids = text_to_ids(h, "Apple pie.", 64, 1)
 print(ids)
-ids = text_to_ids(h, "Эpple pie.", 64, 1)
+ids = text_to_ids(h, u"Эpple pie.", 64, 1)
 print(ids)
 
 print(s)

--- a/scripts/blingfiretok.py
+++ b/scripts/blingfiretok.py
@@ -125,7 +125,7 @@ def text_to_token_with_offsets(s, text_to_token_f, split_byte):
     if len(string_offsets) < num_tokens * 2:
         string_offsets.append(len(s))
             
-    assert len(string_offsets) == num_tokens * 2, f'{len(string_offsets)} != {num_tokens * 2}'
+    assert len(string_offsets) == num_tokens * 2, '%s != %s' % (len(string_offsets), num_tokens * 2)
  
     token_begin_end = [ (b, e) for b, e in zip(string_offsets[::2], string_offsets[1::2])]
         


### PR DESCRIPTION
These simple edits allow both python2 and python3 to run blingfire_example.py