### PR TITLE
Update CSharp bindings to support Span<T> and stackalloc

### DIFF
--- a/nuget/lib/BlingFireNuget.csproj
+++ b/nuget/lib/BlingFireNuget.csproj
@@ -14,8 +14,8 @@
     <PackageReleaseNotes>BlingFire wrapper for .Net Core, see https://github.com/microsoft/BlingFire for details.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.4</Version>
-    <FileVersion>0.1.4</FileVersion>
+    <Version>0.1.5</Version>
+    <FileVersion>0.1.5</FileVersion>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>

--- a/nuget/lib/BlingFireUtils.cs
+++ b/nuget/lib/BlingFireUtils.cs
@@ -25,7 +25,7 @@ namespace BlingFire
 
         [DllImport(BlingFireTokDllName)]
         public static extern int FreeModel(UInt64 model);
-   
+
         public static IEnumerable<string> GetSentences(string paragraph)
         {
             // use Bling Fire TOK for sentence breaking
@@ -53,7 +53,7 @@ namespace BlingFire
             return GetSentencesWithOffsets(Encoding.UTF8.GetBytes(paragraph));
         }
 
-        public static IEnumerable<Tuple<string, int, int>> GetSentencesWithOffsets(byte[] paraBytes)
+        public static IEnumerable<Tuple<string, int, int>> GetSentencesWithOffsets(Span<byte> paraBytes)
         {
             // use Bling Fire TOK for sentence breaking
             int MaxLength = (2 * paraBytes.Length) + 1;
@@ -126,57 +126,237 @@ namespace BlingFire
         //
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToSentences([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, Int32 MaxBuffSize);
+        static extern Int32 TextToSentences(in byte InUtf8Str, Int32 InUtf8StrLen, ref byte OutBuff, Int32 MaxBuffSize);
+        public static Int32 TextToSentences(Span<byte> InUtf8Str, Int32 InUtf8StrLen, Span<byte> OutBuff, Int32 MaxBuffSize)
+        {
+            return TextToSentences(
+                in MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                MaxBuffSize);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToWords([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, Int32 MaxBuffSize);
+        static extern Int32 TextToWords(in byte InUtf8Str, Int32 InUtf8StrLen, ref byte OutBuff, Int32 MaxBuffSize);
+        public static Int32 TextToWords(Span<byte> InUtf8Str, Int32 InUtf8StrLen, Span<byte> OutBuff, Int32 MaxBuffSize)
+        {
+            return TextToWords(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                MaxBuffSize
+                );
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToSentencesWithModel([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, Int32 MaxBuffSize, UInt64 model);
+        static extern Int32 TextToSentencesWithModel(in byte InUtf8Str, Int32 InUtf8StrLen, ref byte OutBuff, Int32 MaxBuffSize, UInt64 model);
+        public static Int32 TextToWords(Span<byte> InUtf8Str, Int32 InUtf8StrLen, Span<byte> OutBuff, Int32 MaxBuffSize, UInt64 model)
+        {
+            return TextToSentencesWithModel(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                MaxBuffSize,
+                model);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToWordsWithModel([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, Int32 MaxBuffSize, UInt64 model);
+        static extern Int32 TextToWordsWithModel(in byte InUtf8Str, Int32 InUtf8StrLen, ref byte OutBuff, Int32 MaxBuffSize, UInt64 model);
+        public static Int32 TextToWordsWithModel(Span<byte> InUtf8Str, Int32 InUtf8StrLen, Span<byte> OutBuff, Int32 MaxBuffSize, UInt64 model)
+        {
+            return TextToWordsWithModel(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                MaxBuffSize,
+                model);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToSentencesWithOffsets([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, int[] StartOffsets, int[] EndOffsets, Int32 MaxBuffSize);
+        static extern Int32 TextToSentencesWithOffsets(
+            in byte InUtf8Str,
+            Int32 InUtf8StrLen,
+            ref byte OutBuff,
+            ref int StartOffsets,
+            ref int EndOffsets,
+            Int32 MaxBuffSize);
+        public static Int32 TextToSentencesWithOffsets(
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<byte> OutBuff,
+            Span<int> StartOffsets,
+            Span<int> EndOffsets,
+            Int32 MaxBuffSize)
+        {
+            return TextToSentencesWithOffsets(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                ref MemoryMarshal.GetReference(StartOffsets),
+                ref MemoryMarshal.GetReference(EndOffsets),
+                MaxBuffSize);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToWordsWithOffsets([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, int[] StartOffsets, int[] EndOffsets, Int32 MaxBuffSize);
+        static extern Int32 TextToWordsWithOffsets(
+            in byte InUtf8Str,
+            Int32 InUtf8StrLen,
+            ref byte OutBuff,
+            ref int StartOffsets,
+            ref int EndOffsets,
+            Int32 MaxBuffSize);
+        public static Int32 TextToWordsWithOffsets(
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<byte> OutBuff,
+            Span<int> StartOffsets,
+            Span<int> EndOffsets,
+            Int32 MaxBuffSize)
+        {
+            return TextToSentencesWithOffsets(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                ref MemoryMarshal.GetReference(StartOffsets),
+                ref MemoryMarshal.GetReference(EndOffsets),
+                MaxBuffSize);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToSentencesWithOffsetsWithModel([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, int[] StartOffsets, int[] EndOffsets, Int32 MaxBuffSize, UInt64 model);
+        static extern Int32 TextToSentencesWithOffsetsWithModel(
+            in byte InUtf8Str,
+            Int32 InUtf8StrLen,
+            ref byte OutBuff,
+            ref int StartOffsets,
+            ref int EndOffsets,
+            Int32 MaxBuffSize,
+            UInt64 model);
+        public static Int32 TextToSentencesWithOffsetsWithModel(
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<byte> OutBuff,
+            Span<int> StartOffsets,
+            Span<int> EndOffsets,
+            Int32 MaxBuffSize,
+            UInt64 model)
+        {
+            return TextToSentencesWithOffsetsWithModel(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                ref MemoryMarshal.GetReference(StartOffsets),
+                ref MemoryMarshal.GetReference(EndOffsets),
+                MaxBuffSize,
+                model);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 TextToWordsWithOffsetsWithModel([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, int[] StartOffsets, int[] EndOffsets, Int32 MaxBuffSize, UInt64 model);
-
+        static extern Int32 TextToWordsWithOffsetsWithModel(
+            in byte InUtf8Str,
+            Int32 InUtf8StrLen,
+            ref byte OutBuff,
+            ref int StartOffsets,
+            ref int EndOffsets,
+            Int32 MaxBuffSize,
+            UInt64 model);
+        public static Int32 TextToWordsWithOffsetsWithModel(
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<byte> OutBuff,
+            Span<int> StartOffsets,
+            Span<int> EndOffsets,
+            Int32 MaxBuffSize,
+            UInt64 model)
+        {
+            return TextToWordsWithOffsetsWithModel(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                ref MemoryMarshal.GetReference(StartOffsets),
+                ref MemoryMarshal.GetReference(EndOffsets),
+                MaxBuffSize,
+                model);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern int TextToIds(
-                UInt64 model,
-                [MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str,
-                Int32 InUtf8StrLen,
-                int[] TokenIds,
-                Int32 MaxBuffSize,
-                int UnkId
-            );
+        static extern int TextToIds(
+            UInt64 model,
+            in byte InUtf8Str,
+            Int32 InUtf8StrLen,
+            ref int TokenIds,
+            Int32 MaxBuffSize,
+            int UnkId);
+        public static int TextToIds(
+            UInt64 model,
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<int> TokenIds,
+            Int32 MaxBuffSize,
+            int UnkId)
+        {
+            return TextToIds(
+                model,
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(TokenIds),
+                MaxBuffSize,
+                UnkId);
+        }
 
         [DllImport(BlingFireTokDllName)]
-        public static extern int TextToIdsWithOffsets(
-                UInt64 model,
-                [MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str,
-                Int32 InUtf8StrLen,
-                int[] TokenIds,
-                int[] StartOffsets,
-                int[] EndOffsets,
-                Int32 MaxBuffSize,
-                int UnkId
-            );
- 
+        static extern int TextToIdsWithOffsets(
+           UInt64 model,
+           in byte InUtf8Str,
+           Int32 InUtf8StrLen,
+           ref int TokenIds,
+           ref int StartOffsets,
+           ref int EndOffsets,
+           Int32 MaxBuffSize,
+           int UnkId);
+        public static int TextToIdsWithOffsets(
+            UInt64 model,
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<int> TokenIds,
+            Span<int> StartOffsets,
+            Span<int> EndOffsets,
+            Int32 MaxBuffSize,
+            int UnkId)
+        {
+            return TextToIdsWithOffsets(
+                model,
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(TokenIds),
+                ref MemoryMarshal.GetReference(StartOffsets),
+                ref MemoryMarshal.GetReference(EndOffsets),
+                MaxBuffSize,
+                UnkId);
+        }
+
         [DllImport(BlingFireTokDllName)]
-        public static extern Int32 NormalizeSpaces([MarshalAs(UnmanagedType.LPArray)] byte[] InUtf8Str, Int32 InUtf8StrLen, byte[] OutBuff, Int32 MaxBuffSize, Int32 utf32SpaceCode);
+        static extern Int32 NormalizeSpaces(
+            in byte InUtf8Str,
+            Int32 InUtf8StrLen,
+            ref byte OutBuff,
+            Int32 MaxBuffSize,
+            Int32 utf32SpaceCode);
+        public static int NormalizeSpaces(
+            Span<byte> InUtf8Str,
+            Int32 InUtf8StrLen,
+            Span<byte> OutBuff,
+            Int32 MaxBuffSize,
+            Int32 utf32SpaceCode)
+        {
+            return NormalizeSpaces(
+                MemoryMarshal.GetReference(InUtf8Str),
+                InUtf8StrLen,
+                ref MemoryMarshal.GetReference(OutBuff),
+                MaxBuffSize,
+                utf32SpaceCode);
+        }
 
         private static char[] _justNewLineChar = new char[] { '\n' };
         private static char[] _justSpaceChar = new char[] { ' ' };
-
     }
 }

--- a/nuget/test/BlingUtilsTest.csproj
+++ b/nuget/test/BlingUtilsTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,9 +10,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
+  
   <ItemGroup>
-    <PackageReference Include="BlingFireNuget" Version="0.1.4" />
+    <PackageReference Include="BlingFireNuget" Version="0.1.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change updates the CSharp nuget to update the public api surfaces to accept Span<byte>/Span<int> instead of byte[] and int[]. This allows the caller more flexibility in passing subsets of data or using stackalloc.

The API surface change should be backward compatible since arrays can be implicitly treated as Spans.

Added a sample in the main Readme.

Tested by building a local nuget and running the test application on windows and Linux (WSL)