### PR TITLE
Add pdb files to nuget package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ ENDIF()
 
 IF (WIN32 AND MSVC)
   set (CMAKE_CXX_FLAGS " -DNDEBUG")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
   add_compile_options("/O2" "/W4" "/GS" "/Gy" "/guard:cf" "/Gm-" "/Zc:inline" "/fp:precise" "/GF" "/EHsc" "/ZH:SHA_256")
   add_compile_options("$<$<CONFIG:Debug>:/Od>")
   add_compile_options("$<$<NOT:$<CONFIG:Debug>>:/GL>")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,13 @@ jobs:
           Contents: $(windowsDllName)
           TargetFolder: '$(build.artifactstagingdirectory)/native'
       
+      - task: CopyFiles@2
+        displayName: 'Copy blingfiretokdll.pdb to: $(Build.ArtifactStagingDirectory)'
+        inputs:
+          SourceFolder: 'Release/Release'
+          Contents: "blingfiretokdll.pdb"
+          TargetFolder: '$(build.artifactstagingdirectory)/native'
+
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: blingfiretokdll.dll'
         inputs:
@@ -99,7 +106,14 @@ jobs:
           SourceFolder: 'Release/Release'
           Contents: $(windowsDllName)
           TargetFolder: '$(build.artifactstagingdirectory)/native'
-      
+
+      - task: CopyFiles@2
+        displayName: 'Copy blingfiretokdll.pdb to: $(Build.ArtifactStagingDirectory)'
+        inputs:
+          SourceFolder: 'Release/Release'
+          Contents: "blingfiretokdll.pdb"
+          TargetFolder: '$(build.artifactstagingdirectory)/native'
+
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: blingfiretokdll.dll'
         inputs:
@@ -317,17 +331,41 @@ jobs:
           artifactName: $(win_X64_Artifact)
           downloadPath: 'nuget/lib/runtimes/win-x64/native'
       
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'nuget/lib/runtimes/win-x64/native/$(win_X64_Artifact)'
+          Contents: '**'
+          TargetFolder: 'nuget/lib/runtimes/win-x64/native'
+          OverWrite: true
+          flattenFolders: true
+      
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Build Artifacts for windows arm64'
         inputs:
           artifactName: $(win_Arm64_Artifact)
           downloadPath: 'nuget/lib/runtimes/win-arm64/native'
       
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'nuget/lib/runtimes/win-arm64/native/$(win_Arm64_Artifact)'
+          Contents: '**'
+          TargetFolder: 'nuget/lib/runtimes/win-arm64/native'
+          OverWrite: true
+          flattenFolders: true
+
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Build Artifacts for osx x64'
         inputs:
           artifactName: $(osx_X64_Artifact)
           downloadPath: 'nuget/lib/runtimes/osx-x64/native'
+      
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'nuget/lib/runtimes/osx-x64/native/$(osx_X64_Artifact)'
+          Contents: '**'
+          TargetFolder: 'nuget/lib/runtimes/osx-x64/native'
+          OverWrite: true
+          flattenFolders: true
       
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Build Artifacts for osx arm64'
@@ -335,17 +373,41 @@ jobs:
           artifactName: $(osx_Arm64_Artifact)
           downloadPath: 'nuget/lib/runtimes/osx-arm64/native'
       
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'nuget/lib/runtimes/osx-arm64/native/$(osx_Arm64_Artifact)'
+          Contents: '**'
+          TargetFolder: 'nuget/lib/runtimes/osx-arm64/native'
+          OverWrite: true
+          flattenFolders: true
+      
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Build Artifacts for linux x64'
         inputs:
           artifactName: $(linux_X64_Artifact)
           downloadPath: 'nuget/lib/runtimes/linux-x64/native'
       
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'nuget/lib/runtimes/linux-x64/native/$(linux_X64_Artifact)'
+          Contents: '**'
+          TargetFolder: 'nuget/lib/runtimes/linux-x64/native'
+          OverWrite: true
+          flattenFolders: true
+
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Build Artifacts for linux Arm64'
         inputs:
           artifactName: $(linux_Arm64_Artifact)
           downloadPath: 'nuget/lib/runtimes/linux-arm64/native'
+      
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'nuget/lib/runtimes/linux-arm64/native/$(linux_Arm64_Artifact)'
+          Contents: '**'
+          TargetFolder: 'nuget/lib/runtimes/linux-arm64/native'
+          OverWrite: true
+          flattenFolders: true
 
       - task: DotNetCoreCLI@2
         inputs:


### PR DESCRIPTION
In this PR:
1. update cmake file to generate debug info for windows.
2. update pipline to copy pdb files to the NuGet package.