### PR TITLE
Fix issues when loadmodel from model file which contains Unicode 

### DIFF
--- a/blingfireclient.library/src/FAImageDump.cpp
+++ b/blingfireclient.library/src/FAImageDump.cpp
@@ -7,7 +7,6 @@
 #include "blingfire-client_src_pch.h"
 #include "FAConfig.h"
 #include "FAImageDump.h"
-#include <stdio.h>
 #include <clocale>
 
 namespace BlingFire

--- a/blingfireclient.library/src/FAImageDump.cpp
+++ b/blingfireclient.library/src/FAImageDump.cpp
@@ -7,6 +7,8 @@
 #include "blingfire-client_src_pch.h"
 #include "FAConfig.h"
 #include "FAImageDump.h"
+#include <stdio.h>
+#include <clocale>
 
 namespace BlingFire
 {
@@ -94,6 +96,7 @@ void FAImageDump::FALoadHeap (const char * pFileName)
     LogAssert (pFileName);
 
     FILE * file = NULL;
+    setlocale(LC_ALL, ".UTF8");
     int res = fopen_s (&file, pFileName, "rb");
     LogAssert (0 == res && NULL != file, "Failed to successfully open file %s", pFileName);
 


### PR DESCRIPTION
This issue happens when there are Unicode characters exist in model file name. To test it I simply modified the nuget test project, updates the model file name from "bert_base_tok.bin" to "bert_base_tok★.bin". Then when we run the test we got the exception:
"
Model File Name is: ./bin/Debug/net6.0/bert_base_tokΓÿà.bin
Unhandled exception. System.Runtime.InteropServices.SEHException (0x80004005): External component has thrown an exception.
   at BlingFire.BlingFireUtils.LoadModel(Byte[] modelName)
"

setlocale(LC_ALL, ".UTF8") fixes this issue. I've tested it on x64-windows and arm64-windows, will do more testes on other platforms.