### PR TITLE
add numpy as a dependency

### DIFF
--- a/dist-pypi/setup.py
+++ b/dist-pypi/setup.py
@@ -12,6 +12,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/blingfire/",
+    install_requires=["numpy"],
     packages=['blingfire'],
     package_data={'blingfire':['bert_base_tok.bin','bert_base_cased_tok.bin','bert_chinese.bin','bert_multi_cased.bin','wbd_chuni.bin','xlnet.bin','xlnet_nonorm.bin','xlm_roberta_base.bin','gpt2.bin','roberta.bin','laser100k.bin','laser250k.bin','laser500k.bin','uri100k.bin','uri250k.bin','uri500k.bin','syllab.bin','bert_base_cased_tok.i2w', 'bert_base_tok.i2w', 'bert_chinese.i2w', 'bert_multi_cased.i2w', 'gpt2.i2w', 'laser100k.i2w', 'laser250k.i2w', 'laser500k.i2w', 'roberta.i2w', 'uri100k.i2w', 'uri250k.i2w', 'uri500k.i2w', 'xlm_roberta_base.i2w', 'xlnet.i2w', 'xlnet_nonorm.i2w', 'libblingfiretokdll.so','blingfiretokdll.dll','blingfiretokdll.pdb','libblingfiretokdll.dylib']},
     classifiers=[


### PR DESCRIPTION
When using blingfire with python, numpy was missing:
`site-packages/blingfire/__init__.py", line 5, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
`
So I added it as a dependency. I tested it locally as well on my computer at it worked.